### PR TITLE
Update analytics events

### DIFF
--- a/typescript/server/cart.ts
+++ b/typescript/server/cart.ts
@@ -14,11 +14,6 @@ app.post('/cart', (req, res) => {
 });
 
 app.post('/savecart', (req, res) => {
-    analytics.track({
-      userId: req.body.userId,
-      event: 'Save for later',
-      properties: { productId: '99482' }
-    })
      res.sendStatus(201)
   });
 

--- a/typescript/server/order.ts
+++ b/typescript/server/order.ts
@@ -13,7 +13,7 @@ app.post('/createorder', (req, res) => {
     analytics.track({
       userId: req.body.userId,
       event: 'Create order',
-      properties: { orderId: '99482', numOfProducts: '5' }
+      properties: { orderId: '99482' }
     })
      res.sendStatus(201)
   });


### PR DESCRIPTION
# Summary

Updates to the analytics events we're tracking in the store frontend

* Stop tracking the `Save for later` event as it's redundant
* Remove `numOfProducts` from the `Create order` - we can just compute it in the warehouse based on the database entry for the order